### PR TITLE
change language name from GO to Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="web/src/images/kaamer.svg" alt="kAAmer logo" width="40px"/> kAAmer
 
-kAAmer is a GO package that provides the tools to produce and query a kmerized protein database.
+kAAmer is a Go package that provides the tools to produce and query a kmerized protein database.
 
 It provides fast protein and translated nucleotide searches over a protein database while lacking the sensitivity of alignment when it comes to find distant homology.
 


### PR DESCRIPTION
On Wikipedia, it is Go. On https://golang.org/ too.